### PR TITLE
Removes console.log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 import { registerPlugin } from '@capacitor/core'
 import type { SecureStoragePlugin } from './definitions'
-import info from './info.json'
-
-console.log(`loaded ${info.name} v${info.version}`)
 
 const proxy = registerPlugin<SecureStoragePlugin>('SecureStorage', {
   web: async () =>


### PR DESCRIPTION
@aparajita this log is polluting our unit tests logs. If this is really needed, maybe this should be made configurable, so that those who use this plugin can decide if they want to see the log or not.