### PR TITLE
Feature/using encrypted shared preferences

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,4 +48,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation "androidx.security:security-crypto:1.0.0"
 }

--- a/android/src/main/java/com/aparajita/capacitor/securestorage/SecureStorage.java
+++ b/android/src/main/java/com/aparajita/capacitor/securestorage/SecureStorage.java
@@ -3,171 +3,206 @@ package com.aparajita.capacitor.securestorage;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
-import android.security.KeyPairGeneratorSpec;
-import android.security.keystore.KeyGenParameterSpec;
-import android.security.keystore.KeyProperties;
-import android.util.Base64;
-
 import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKeys;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
-import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
-import org.json.JSONArray;
-
 import java.io.IOException;
-import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.UnrecoverableKeyException;
-import java.security.spec.AlgorithmParameterSpec;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Enumeration;
+import java.util.Map;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
-import javax.security.auth.x500.X500Principal;
 
-interface StorageOp {
-  void run() throws KeyStoreException, GeneralSecurityException, IOException;
-}
+import org.json.JSONArray;
 
 @CapacitorPlugin(name = "SecureStorage")
 public class SecureStorage extends Plugin {
 
-  // KeyStore-related stuff
+  private static final String SHARED_PREFERENCES = "WSSecureStorageSharedPreferences";
   private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
   private static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
-  private static final String SHARED_PREFERENCES = "WSSecureStorageSharedPreferences";
   private static final Character DATA_IV_SEPARATOR = '\u0010';
   private static final int BASE64_FLAGS = Base64.NO_PADDING + Base64.NO_WRAP;
 
-  private KeyStore keyStore;
   private SharedPreferences sharedPreferences = null;
+  private KeyStore keyStore;
+  private boolean migrationDone = false;
 
   @PluginMethod
   public void internalSetItem(final PluginCall call) {
-    String key = getKeyParam(call);
-
+    String key = call.getString("key");
     if (key == null) {
+      call.reject("Key parameter is missing");
       return;
     }
-
-    String data = getDataParam(call);
-
+    String data = call.getString("data");
     if (data == null) {
+      call.reject("Data parameter is missing");
       return;
     }
 
-    tryStorageOp(
-      call,
-      () -> {
+    tryStorageOp(call, () -> {
+      if (isAndroidMOrHigher()) {
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.putString(key, data);
+        editor.apply();
+      } else {
         storeDataInKeyStore(key, data);
-        call.resolve();
       }
-    );
+      call.resolve();
+    });
   }
 
   @PluginMethod
   public void internalGetItem(final PluginCall call) {
-    String key = getKeyParam(call);
-
+    String key = call.getString("key");
     if (key == null) {
+      call.reject("Key parameter is missing");
       return;
     }
 
-    tryStorageOp(
-      call,
-      () -> {
-        String data = getDataFromKeyStore(key);
-        JSObject result = new JSObject();
-        result.put("data", data != null ? data : JSObject.NULL);
-        call.resolve(result);
+    tryStorageOp(call, () -> {
+      String data;
+      if (isAndroidMOrHigher()) {
+        data = getPrefs().getString(key, null);
+      } else {
+        data = getDataFromKeyStore(key);
       }
-    );
+      JSObject result = new JSObject();
+      result.put("data", data != null ? data : JSObject.NULL);
+      call.resolve(result);
+    });
   }
 
   @PluginMethod
   public void internalRemoveItem(final PluginCall call) {
-    String key = getKeyParam(call);
-
+    String key = call.getString("key");
     if (key == null) {
+      call.reject("Key parameter is missing");
       return;
     }
 
-    tryStorageOp(
-      call,
-      () -> {
-        boolean success = removeDataFromKeyStore(key);
-        JSObject result = new JSObject();
-        result.put("success", success);
-        call.resolve(result);
+    tryStorageOp(call, () -> {
+      if (isAndroidMOrHigher()) {
+        SharedPreferences.Editor editor = getPrefs().edit();
+        editor.remove(key);
+        editor.apply();
+      } else {
+        removeDataFromKeyStore(key);
       }
-    );
+      call.resolve();
+    });
   }
 
   @PluginMethod
   public void clearItemsWithPrefix(final PluginCall call) {
-    tryStorageOp(
-      call,
-      () -> {
-        String prefix = call.getString("_prefix", "");
+    String prefix = call.getString("_prefix", "");
+    tryStorageOp(call, () -> {
+      if (isAndroidMOrHigher()) {
+        Map < String, ? > allEntries = getPrefs().getAll();
+        SharedPreferences.Editor editor = getPrefs().edit();
+        for (Map.Entry < String, ? > entry : allEntries.entrySet()) {
+          if (entry.getKey().startsWith(prefix)) {
+            editor.remove(entry.getKey());
+          }
+        }
+        editor.apply();
+      } else {
         clearKeyStore(prefix);
-        call.resolve();
       }
-    );
+      call.resolve();
+    });
   }
 
   @PluginMethod
   public void getPrefixedKeys(final PluginCall call) {
-    tryStorageOp(
-      call,
-      () -> {
-        String prefix = call.getString("prefix", "");
-        ArrayList<String> keys = getKeysWithPrefix(prefix);
-        JSONArray array = new JSONArray(keys);
-
-        JSObject result = new JSObject();
-        result.put("keys", array);
-        call.resolve(result);
+    String prefix = call.getString("prefix", "");
+    tryStorageOp(call, () -> {
+      ArrayList < String > filteredKeys = new ArrayList < > ();
+      if (isAndroidMOrHigher()) {
+        Map < String, ? > allEntries = getPrefs().getAll();
+        for (Map.Entry < String, ? > entry : allEntries.entrySet()) {
+          if (entry.getKey().startsWith(prefix)) {
+            filteredKeys.add(entry.getKey());
+          }
+        }
+      } else {
+        filteredKeys = getKeysWithPrefix(prefix);
       }
-    );
+
+      JSONArray resultArray = new JSONArray(filteredKeys);
+      JSObject result = new JSObject();
+      result.put("keys", resultArray);
+      call.resolve(result);
+    });
   }
 
   private SharedPreferences getPrefs() {
-    if (sharedPreferences == null){
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    if (sharedPreferences == null) {
+      SharedPreferences oldPrefs = getContext().getSharedPreferences(SHARED_PREFERENCES, Context.MODE_PRIVATE);
+      if (isAndroidMOrHigher && !migrationDone) {
         try {
-          String masterKey = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC);
+          String masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC);
           sharedPreferences = EncryptedSharedPreferences.create(
             SHARED_PREFERENCES,
-            masterKey,
+            masterKeyAlias,
             getContext(),
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM);
+
+          // Migrate data if needed
+          if (needsMigration(oldPrefs)) {
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+            Map < String, ? > entries = oldPrefs.getAll();
+            for (Map.Entry < String, ? > entry : entries.entrySet()) {
+              if (entry.getValue() instanceof String) {
+                editor.putString(entry.getKey(), (String) entry.getValue());
+              }
+            }
+            editor.apply();
+            oldPrefs.edit().clear().apply();
+          }
+          migrationDone = true;
         } catch (GeneralSecurityException | IOException e) {
           e.printStackTrace();
         }
-      }
-      if (sharedPreferences == null){
-        //Use default
-        sharedPreferences = getContext().getSharedPreferences(SHARED_PREFERENCES, Context.MODE_PRIVATE);
+      } else {
+        sharedPreferences = oldPrefs;
       }
     }
     return sharedPreferences;
   }
 
+  private boolean needsMigration(SharedPreferences prefs) {
+    return prefs.getAll().size() > 0;
+  }
+
+  private KeyStore getKeyStore() throws GeneralSecurityException, IOException {
+    if (keyStore == null) {
+      keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+      keyStore.load(null);
+    }
+    return keyStore;
+  }
+
   private void storeDataInKeyStore(String prefixedKey, String data) throws GeneralSecurityException, IOException {
     // When we get here, we know that the values are not null
-    getPrefs().edit().putString(prefixedKey, encryptString(data, prefixedKey)).apply();
+    getPrefs()
+      .edit()
+      .putString(prefixedKey, encryptString(data, prefixedKey))
+      .apply();
   }
 
   private String getDataFromKeyStore(String prefixedKey) throws KeyStoreException, GeneralSecurityException, IOException {
@@ -187,26 +222,27 @@ public class SecureStorage extends Plugin {
     }
   }
 
-  private boolean removeDataFromKeyStore(String prefixedKey) throws GeneralSecurityException, IOException {
+  private void removeDataFromKeyStore(String prefixedKey) throws GeneralSecurityException, IOException {
     KeyStore keyStore = getKeyStore();
     return removeAlias(keyStore, prefixedKey);
   }
 
-  private boolean removeAlias(KeyStore keyStore, String alias) throws java.security.KeyStoreException {
-    if (keyStore.containsAlias(alias)) {
-      keyStore.deleteEntry(alias);
-      getPrefs().edit().remove(alias).apply();
-      return true;
-    }
-
-    return false;
-  }
-
-  private ArrayList<String> getKeysWithPrefix(String prefix) throws GeneralSecurityException, IOException {
-    ArrayList<String> keys = new ArrayList<>();
+  private void clearKeyStore(String prefix) throws GeneralSecurityException, IOException {
+    ArrayList < String > keys = getKeysWithPrefix(prefix);
     KeyStore keyStore = getKeyStore();
 
-    for (Enumeration<String> aliases = keyStore.aliases(); aliases.hasMoreElements(); ) {
+    for (String key: keys) {
+      removeAlias(keyStore, key);
+    }
+  }
+
+  private ArrayList < String > getKeysWithPrefix(String prefix) throws GeneralSecurityException, IOException {
+    ArrayList < String > keys = new ArrayList < > ();
+    KeyStore keyStore = getKeyStore();
+
+    for (
+      Enumeration < String > aliases = keyStore.aliases(); aliases.hasMoreElements();
+    ) {
       String alias = aliases.nextElement();
 
       if (alias.startsWith(prefix)) {
@@ -217,55 +253,19 @@ public class SecureStorage extends Plugin {
     return keys;
   }
 
-  private void clearKeyStore(String prefix) throws GeneralSecurityException, IOException {
-    ArrayList<String> keys = getKeysWithPrefix(prefix);
-    KeyStore keyStore = getKeyStore();
-
-    for (String key : keys) {
-      removeAlias(keyStore, key);
-    }
-  }
-
-  private void tryStorageOp(PluginCall call, StorageOp op) {
-    KeyStoreException exception;
-
-    try {
-      op.run();
-      return;
-    } catch (KeyStoreException e) {
-      exception = e;
-    } catch (GeneralSecurityException | IOException e) {
-      exception = new KeyStoreException(KeyStoreException.ErrorKind.osError, e);
-    } catch (Exception e) {
-      exception = new KeyStoreException(KeyStoreException.ErrorKind.unknownError);
+  private boolean removeAlias(KeyStore keyStore, String alias)
+    throws java.security.KeyStoreException {
+    if (keyStore.containsAlias(alias)) {
+      keyStore.deleteEntry(alias);
+      getPrefs().edit().remove(alias).apply();
+      return true;
     }
 
-    exception.rejectCall(call);
+    return false;
   }
 
-  private String getKeyParam(PluginCall call) {
-    String key = call.getString("prefixedKey");
-
-    if (key != null && !key.isEmpty()) {
-      return key;
-    }
-
-    KeyStoreException.reject(call, KeyStoreException.ErrorKind.missingKey);
-    return null;
-  }
-
-  private String getDataParam(PluginCall call) {
-    String value = call.getString("data");
-
-    if (value != null) {
-      return value;
-    }
-
-    KeyStoreException.reject(call, KeyStoreException.ErrorKind.invalidData);
-    return null;
-  }
-
-  private String encryptString(String str, String prefixedKey) throws GeneralSecurityException, IOException {
+  private String encryptString(String str, String prefixedKey)
+    throws GeneralSecurityException, IOException {
     // Code taken from https://medium.com/@josiassena/using-the-android-keystore-system-to-store-sensitive-information-3a56175a454b
     Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
     cipher.init(Cipher.ENCRYPT_MODE, getSecretKey(prefixedKey));
@@ -281,7 +281,8 @@ public class SecureStorage extends Plugin {
     return encryptedStr + DATA_IV_SEPARATOR + ivStr;
   }
 
-  private String decryptString(String ciphertext, String prefixedKey) throws GeneralSecurityException, IOException, KeyStoreException {
+  private String decryptString(String ciphertext, String prefixedKey)
+    throws GeneralSecurityException, IOException, KeyStoreException {
     // Code taken from https://medium.com/@josiassena/using-the-android-keystore-system-to-store-sensitive-information-3a56175a454b
 
     // Split the ciphertext into data + IV
@@ -297,11 +298,12 @@ public class SecureStorage extends Plugin {
     byte[] iv = Base64.decode(parts[1], BASE64_FLAGS);
 
     KeyStore keyStore = getKeyStore();
-    KeyStore.SecretKeyEntry secretKeyEntry = (KeyStore.SecretKeyEntry) keyStore.getEntry(prefixedKey, null);
+    KeyStore.SecretKeyEntry secretKeyEntry =
+      (KeyStore.SecretKeyEntry) keyStore.getEntry(prefixedKey, null);
 
     // Make sure there is an entry in the KeyStore for the given domain
     if (secretKeyEntry == null) {
-      throw new KeyStoreException(KeyStoreException.ErrorKind.notFound, prefixedKey);
+      return null;
     }
 
     SecretKey secretKey = secretKeyEntry.getSecretKey();
@@ -313,64 +315,27 @@ public class SecureStorage extends Plugin {
     return new String(decryptedData, StandardCharsets.UTF_8);
   }
 
-  private SecretKey getSecretKey(String prefixedKey) throws GeneralSecurityException, IOException {
-    KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", ANDROID_KEY_STORE);
-    KeyStore keyStore = getKeyStore();
-    KeyStore.SecretKeyEntry entry = null;
+  private void tryStorageOp(PluginCall call, StorageOp op) {
+    KeyStoreException exception;
 
     try {
-      entry = (KeyStore.SecretKeyEntry) keyStore.getEntry(prefixedKey, null);
-    } catch (UnrecoverableKeyException e) {
-      // We haven't yet generated a secret key for prefixedKey, generate one
+      op.run();
+      return;
+    } catch (KeyStoreException e) {
+      exception = e;
+    } catch (GeneralSecurityException | IOException e) {
+      exception = new KeyStoreException(KeyStoreException.ErrorKind.osError, e);
+    } catch (Exception e) {
+      exception = new KeyStoreException(
+        KeyStoreException.ErrorKind.unknownError,
+        e
+      );
     }
-
-    SecretKey secretKey;
-
-    if (entry == null) {
-      AlgorithmParameterSpec spec;
-
-      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-        KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(
-          prefixedKey,
-          KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT
-        );
-        spec =
-          builder
-            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-            .build();
-      } else {
-        // Let the key pair last for 1 year
-        Calendar start = Calendar.getInstance();
-        Calendar end = Calendar.getInstance();
-        end.add(Calendar.YEAR, 1);
-
-        KeyPairGeneratorSpec.Builder builder = new KeyPairGeneratorSpec.Builder(getContext());
-        spec =
-          builder
-            .setAlias(prefixedKey)
-            .setSubject(new X500Principal("CN=" + prefixedKey))
-            .setSerialNumber(BigInteger.ONE)
-            .setStartDate(start.getTime())
-            .setEndDate(end.getTime())
-            .build();
-      }
-
-      keyGenerator.init(spec);
-      secretKey = keyGenerator.generateKey();
-    } else {
-      secretKey = entry.getSecretKey();
-    }
-
-    return secretKey;
+    exception.rejectCall(call);
   }
 
-  private KeyStore getKeyStore() throws GeneralSecurityException, IOException {
-    if (keyStore == null) {
-      keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
-      keyStore.load(null);
-    }
-
-    return keyStore;
+  // EncryptedSharedPreferences >= Android 6.0 Marshmallow
+  private boolean isAndroidMOrHigher() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
   }
 }


### PR DESCRIPTION
Continue [PR-9](https://github.com/aparajita/capacitor-secure-storage/pull/9) by @tuanbipa.

## **Description of the Change**

The changes focus on introducing modern secure storage practices in Android by using `EncryptedSharedPreferences` for Android 6.0 (Marshmallow) and above, while maintaining compatibility with older Android versions via the `KeyStore` system. The solution includes automatic data migration, ensuring a seamless transition without data loss.

---

## **Change List**

### 1. Support for `EncryptedSharedPreferences`
- **New Feature:** Utilizes `EncryptedSharedPreferences` for secure data storage on Android 6.0+.
- **Data Migration:** Automatically transfers data from legacy `SharedPreferences` to `EncryptedSharedPreferences`.

### 2. Backward Compatibility for Android < 6.0
- Retains the use of the `KeyStore` system for data encryption and decryption on older Android versions.

### 3. Introduction of `migrationDone` Flag
- **Purpose:** Ensures that data migration happens only once, avoiding unnecessary processing.

### 4. Helper Method `isAndroidMOrHigher`
- **Purpose:** Checks the device's Android version to determine if `EncryptedSharedPreferences` can be used.

### 5. Refactored `getPrefs` Method
- **Enhancement:**
  - Manages the creation of `EncryptedSharedPreferences` for Android 6.0+.
  - Handles data migration from legacy `SharedPreferences` to `EncryptedSharedPreferences`.
  - Falls back to plain `SharedPreferences` for Android versions below 6.0.
